### PR TITLE
Remove columns from column selector in certain listviews where those …

### DIFF
--- a/RpcInvestigator.csproj
+++ b/RpcInvestigator.csproj
@@ -101,8 +101,8 @@
     <Reference Include="NtApiDotNet.Forms, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>packages\NtApiDotNet.Forms.1.1.33\lib\net461\NtApiDotNet.Forms.dll</HintPath>
     </Reference>
-    <Reference Include="ObjectListView, Version=2.9.1.25410, Culture=neutral, PublicKeyToken=b1c5bf581481bcd4, processorArchitecture=MSIL">
-      <HintPath>packages\ObjectListView.Official.2.9.2-alpha2\lib\net20\ObjectListView.dll</HintPath>
+    <Reference Include="ObjectListView, Version=2.9.1.25354, Culture=neutral, PublicKeyToken=b1c5bf581481bcd4, processorArchitecture=MSIL">
+      <HintPath>packages\ObjectListView-ToB.2.9.4\lib\net20\ObjectListView.dll</HintPath>
     </Reference>
     <Reference Include="PresentationCore" />
     <Reference Include="PresentationFramework" />

--- a/TabPages/TabManager.cs
+++ b/TabPages/TabManager.cs
@@ -134,6 +134,38 @@ namespace RpcInvestigator.TabPages
             return libraryProceduresTab;
         }
 
+        public RpcLibraryProcedureList LoadRpcLibraryProceduresTab(RpcServer Server)
+        {
+            TabPage tab;
+            RpcLibraryProcedureList libraryProceduresTab;
+            var tabName = "Procedures for ";
+            if (!string.IsNullOrEmpty(Server.ServiceName))
+            {
+                tabName += Server.ServiceName;
+            }
+            else if (!string.IsNullOrEmpty(Server.Name))
+            {
+                tabName += Server.Name;
+            }
+            else
+            {
+                tabName += Server.InterfaceId.ToString();
+            }
+
+            if (!TabExists(tabName, out tab))
+            {
+                tab = new RpcLibraryProcedureList(m_Library);
+                tab.Text = tabName; // override name
+                m_TabControl.TabPages.Add(tab);
+            }
+            libraryProceduresTab = tab as RpcLibraryProcedureList;
+            _ = libraryProceduresTab.Build(Server);
+            m_TabControl.SelectedTab = libraryProceduresTab;
+            m_StatusLabel.Text = "Loaded " + libraryProceduresTab.GetCount() +
+                " procedures from the library";
+            return libraryProceduresTab;
+        }
+
         public bool TabExists(string Name, out TabPage Match)
         {
             Match = null;

--- a/Windows/Controls/SnifferListview.cs
+++ b/Windows/Controls/SnifferListview.cs
@@ -53,6 +53,7 @@ namespace RpcInvestigator.Windows.Controls
             AlternateRowBackColor = Color.LightBlue;
             UseCompatibleStateImageBehavior = false;
             VirtualMode = true;
+            UseFiltering = true;
             if (m_Settings.m_SnifferColumns.Count() == 0)
             {
                 m_ChosenColumns = new List<string>() {

--- a/packages.config
+++ b/packages.config
@@ -3,13 +3,13 @@
   <package id="FCTB" version="2.16.24" targetFramework="net481" />
   <package id="GraphX" version="3.0.0" targetFramework="net481" />
   <package id="Newtonsoft.Json" version="13.0.2" targetFramework="net481" />
-  <package id="NtApiDotNet" version="1.1.33" targetFramework="net472" />
-  <package id="NtApiDotNet.Forms" version="1.1.33" targetFramework="net472" />
-  <package id="ObjectListView.Official" version="2.9.2-alpha2" targetFramework="net472" />
+  <package id="NtApiDotNet" version="1.1.33" targetFramework="net481" />
+  <package id="NtApiDotNet.Forms" version="1.1.33" targetFramework="net481" />
+  <package id="ObjectListView-ToB" version="2.9.4" targetFramework="net481" />
   <package id="QuickGraphCore" version="1.0.0" targetFramework="net481" />
-  <package id="System.Buffers" version="4.4.0" targetFramework="net472" />
-  <package id="System.Memory" version="4.5.3" targetFramework="net472" />
-  <package id="System.Numerics.Vectors" version="4.4.0" targetFramework="net472" />
-  <package id="System.Resources.Extensions" version="4.6.0" targetFramework="net472" />
+  <package id="System.Buffers" version="4.4.0" targetFramework="net481" />
+  <package id="System.Memory" version="4.5.3" targetFramework="net481" />
+  <package id="System.Numerics.Vectors" version="4.4.0" targetFramework="net481" />
+  <package id="System.Resources.Extensions" version="4.6.0" targetFramework="net481" />
   <package id="System.Runtime.CompilerServices.Unsafe" version="5.0.0" targetFramework="net481" />
 </packages>


### PR DESCRIPTION
…columns cause sort crashes. Add a right-click context menu option to view procedures from both the RPCALPC server list and the library server list.  RPCI also now uses our own private build of ObjectListView control, as a nuget package.