### PR TITLE
Export now also exports procedures

### DIFF
--- a/TabPages/RpcProcedureList.cs
+++ b/TabPages/RpcProcedureList.cs
@@ -16,6 +16,8 @@ using NtApiDotNet;
 using NtApiDotNet.Ndr;
 using System.Diagnostics;
 using RpcInvestigator.Util;
+using System.Windows.Controls;
+using System.IO;
 
 namespace RpcInvestigator
 {
@@ -112,6 +114,36 @@ namespace RpcInvestigator
                 return 0;
             }
             return m_Listview.Objects.Cast<NdrProcedureDefinition>().Count();
+        }
+
+        public void ExportProceduresToFile(string filePath)
+        {
+            string procInfoStr = new string("");
+            foreach (NdrProcedureDefinition proc in m_Listview.Objects.Cast<NdrProcedureDefinition>())
+            {
+                procInfoStr += proc.Name + "\n";
+                procInfoStr += "\tParams\n";
+                
+                foreach (var param in proc.Params)
+                {
+                    procInfoStr += "\t\t" + param.ToString() + "\n";
+                }
+
+                procInfoStr += "\tReturn Value: " + proc.ReturnValue.ToString() + "\n";
+                procInfoStr += "\tHandle:" + proc.Handle.ToString() + "\n";
+                procInfoStr += "\tRpc Flags:" + proc.RpcFlags.ToString() + "\n";
+                procInfoStr += "\tProc Num:" + proc.ProcNum.ToString() + "\n";
+                procInfoStr += "\tStack Size:" + proc.StackSize.ToString() + "\n";
+                procInfoStr += "\tHas Async Handle:" + proc.HasAsyncHandle.ToString() + "\n";
+                procInfoStr += "\tDispatch Function:" + proc.DispatchFunction.ToString() + "\n";
+                procInfoStr += "\tDispatch Offset:" + proc.DispatchOffset.ToString() + "\n";
+                procInfoStr += "\tInterpreter Flags:" + proc.InterpreterFlags.ToString() + "\n";
+            }
+            procInfoStr += "\n";
+            FileStream file = new FileStream(filePath, FileMode.Append, FileAccess.Write, FileShare.None);
+            byte[] strBytes = Encoding.UTF8.GetBytes(procInfoStr);
+            file.Write(strBytes, 0, strBytes.Length);
+            file.Close();
         }
 
         private static string BuildTabTitle(string Name)

--- a/TabPages/TabManager.cs
+++ b/TabPages/TabManager.cs
@@ -80,6 +80,10 @@ namespace RpcInvestigator.TabPages
             return endpointsTab;
         }
 
+        public TabPage GetSelectedTabPage()
+        {
+            return m_TabControl.SelectedTab;
+        }
         public RpcProcedureList LoadRpcProceduresTab(string Name, List<NdrProcedureDefinition> Procedures)
         {
             TabPage tab;

--- a/Windows/MainWindow.cs
+++ b/Windows/MainWindow.cs
@@ -297,13 +297,22 @@ namespace RpcInvestigator
             ToggleMenu(false);
             var location = Path.Combine(new string[] { Settings.m_LogDir,
                  "library-text-"+Path.GetRandomFileName() + ".txt" });
+            
             File.WriteAllText(location, m_Library.ToString());
+            
+            if (m_TabManager.GetSelectedTabPage() is RpcProcedureList)
+            {
+                RpcProcedureList rpcProcedureList = m_TabManager.GetSelectedTabPage() as RpcProcedureList;
+                rpcProcedureList.ExportProceduresToFile(location);
+            }
+
             var psi = new ProcessStartInfo();
             psi.FileName = location;
             psi.WorkingDirectory = Directory.GetParent(location).FullName;
             psi.UseShellExecute = true;
             Process.Start(psi);
             ToggleMenu(true);
+
         }
 
         private void rPCSnifferToolStripMenuItem_Click(object sender, EventArgs e)


### PR DESCRIPTION
The export as text button now also exports procedures when procedures tab is the currently active one.

![image](https://github.com/trailofbits/RpcInvestigator/assets/1687568/c9518a23-4fc8-4902-802a-b9a43c8d78a5)


